### PR TITLE
Add pyribs to libraries page

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -2,13 +2,13 @@
 
 
 ## Sferes2 (C++11)
-[https://github.com/sferes2/sferes2](https://github.com/sferes2/sferes2)
+- [GitHub](https://github.com/sferes2/sferes2)
 
 ## QDpy (Python)
-[https://gitlab.com/leo.cazenille/qdpy](https://gitlab.com/leo.cazenille/qdpy)
+- [GitHub](https://gitlab.com/leo.cazenille/qdpy)
 
 ## CVT-Map-Elites (Python)
-[https://github.com/resibots/pymap_elites](https://github.com/resibots/pymap_elites)
+- [GitHub](https://github.com/resibots/pymap_elites)
 
 ## pyribs (Python)
 

--- a/libraries.md
+++ b/libraries.md
@@ -7,5 +7,11 @@
 ## QDpy (Python)
 [https://gitlab.com/leo.cazenille/qdpy](https://gitlab.com/leo.cazenille/qdpy)
 
-### CVT-Map-Elites (Python)
+## CVT-Map-Elites (Python)
 [https://github.com/resibots/pymap_elites](https://github.com/resibots/pymap_elites)
+
+## pyribs (Python)
+
+- [Website](https://pyribs.org)
+- [GitHub](https://github.com/icaros-usc/pyribs)
+- [Documentation](https://docs.pyribs.org)


### PR DESCRIPTION
Hi @Aneoshun, I am a PhD student with the ICAROS Lab at USC. We recently released pyribs, a quality diversity library focused on CMA-ME, and we hope to list it on this website as well.

In this PR, I have added the links for pyribs to the Libraries page of the site. I added all the links for pyribs, but I noticed that the other libraries listed only have GitHub links, so feel free to remove links as needed.

Let me know if it looks good. Thanks!