### PR TITLE
Add ICAROS lab paper from NeurIPS 2022

### DIFF
--- a/_data/paperlist.yml
+++ b/_data/paperlist.yml
@@ -3016,3 +3016,16 @@ papers:
           series = {GECCO '22}
           }
           "
+
+- title: "Deep Surrogate Assisted Generation of Environments"
+  authors:
+   -  Varun Bhatt
+   -  Bryon Tjanaka
+   -  Matthew C. Fontaine
+   -  Stefanos Nikolaidis
+  year: 2022
+  tags:
+   - scenario generation
+  pdfurl: "arxiv.org/abs/2206.04199"
+  abstract: "Recent progress in reinforcement learning (RL) has started producing generally capable agents that can solve a distribution of complex environments. These agents are typically tested on fixed, human-authored environments. On the other hand, quality diversity (QD) optimization has been proven to be an effective component of environment generation algorithms, which can generate collections of high-quality environments that are diverse in the resulting agent behaviors. However, these algorithms require potentially expensive simulations of agents on newly generated environments. We propose Deep Surrogate Assisted Generation of Environments (DSAGE), a sample-efficient QD environment generation algorithm that maintains a deep surrogate model for predicting agent behaviors in new environments. Results in two benchmark domains show that DSAGE significantly outperforms existing QD environment generation algorithms in discovering collections of environments that elicit diverse behaviors of a state-of-the-art RL agent and a planning agent. Our source code and videos are available at https://dsagepaper.github.io/"
+  bibtex: 


### PR DESCRIPTION
I have added our paper on environment generation accepted at NeurIPS 2022. Since the proceedings are not out yet, I have kept the bibtex field empty. I will update it once the proceedings are released.